### PR TITLE
流式输出--最小原型

### DIFF
--- a/backend/app/llm/qwen_client.py
+++ b/backend/app/llm/qwen_client.py
@@ -1,6 +1,6 @@
 # app/llm/qwen_client.py 千问大模型客户端
-from typing import Optional, List, Dict, Any
-from app.utils.request import send_request_async
+from typing import Optional, List, Dict, Any, AsyncGenerator, Tuple
+from app.utils.request import send_request_async, send_stream_request_async
 import json
 from datetime import datetime
 
@@ -38,38 +38,136 @@ _llm_context = LLMContext(
 [DISGUSTED] - 厌恶的情绪，反感的回答
 [SURPRISED] - 惊讶的情绪，意外的回答
 
+在回答过程中，每当情绪发生变化时，你需要在句号后标注新的情绪类型。如果后续句子与前面句子为同一情绪类型，则不需要重复标注。
+
 例如：
 [HAPPY]
-很高兴能帮助到你！
-
-[NEUTRAL]
-根据我的分析，这个问题的答案是...
+很高兴能帮助到你！这个问题很有趣。[NEUTRAL] 让我来详细分析一下。首先需要考虑几个方面。[SURPRISED] 哇，这个结果真是令人意外！
 
 请根据回答内容选择最合适的情绪类型。情绪标注仅用于语音合成时的语气调整，不代表你真实的情感。"""
 )
 
-async def simple_send_request_to_llm(text: str) -> Optional[str]:
+async def simple_send_request_to_llm(text: str) -> AsyncGenerator[str, None]:
     """
-    简单发送请求到LLM
+    简单发送请求到LLM（使用流式输出），每遇到句子结束符就发送一个完整的句子
+    返回一个异步生成器，每次生成一个完整的句子
     """
     # 将用户输入添加到待处理区，这里暂时还没有多模态数据 # [TODO] 多模态
     is_ended = await add_new_transcript_to_context(text, _global_to_be_processed_turns, _llm_context)
     if not is_ended:
-        # 说明还没有结束，直接返回 None
-        return None
-
+        # 说明还没有结束，直接返回
+        return
+    
     # 获取格式化后的消息列表
     messages = _llm_context.format_for_llm()
-
-    response, _, _ = await send_request_async(messages, "qwen-turbo-latest")
     
-    # 将模型响应添加到上下文历史
-    _llm_context.history.append(AgentResponseTurn(response=response))
-
-    print(f"【调试】[QwenClient] 收到LLM响应: {response}")
-
-    # 不需要在这里移除情绪标记，因为TTS服务会处理
-    return response
+    # 用于累积完整响应
+    full_response = ""
+    # 当前句子缓存
+    current_sentence = ""
+    
+    # 定义句子结束的标点符号
+    sentence_end_marks = ['。', '！', '？', '…', '!', '?', '.']
+    
+    print(f"【调试】[QwenClient] 开始流式请求")
+    
+    try:
+        # 使用流式请求处理每个响应块
+        async for chunk, total_token, generation_token in send_stream_request_async(messages, "qwen-turbo-latest"):
+            # 累积完整响应
+            full_response += chunk
+            current_sentence += chunk
+            
+            # 打印每个流式块用于调试
+            print(f"【调试】[QwenClient] 流式块: {chunk}")
+            
+            # 检查是否有任何句子结束符
+            has_end_mark = False
+            
+            # 查找所有可能的句子结束标记
+            for end_mark in sentence_end_marks:
+                while end_mark in current_sentence:
+                    has_end_mark = True
+                    # 找到结束符的位置
+                    end_pos = current_sentence.find(end_mark)
+                    
+                    # 处理英文句号的特殊情况（避免将缩写词和数字中的点识别为句子结束）
+                    if end_mark == '.' and end_pos > 0:
+                        # 检查前一个字符是否为数字，如果是，可能是小数点
+                        prev_char = current_sentence[end_pos-1]
+                        # 检查句号后是否还有字符
+                        has_next = end_pos+1 < len(current_sentence)
+                        next_char = current_sentence[end_pos+1] if has_next else ""
+                        
+                        # 如果句号前后都是数字，可能是小数点，不应该分割
+                        if prev_char.isdigit() and (has_next and next_char.isdigit()):
+                            # 移动到下一个位置继续搜索
+                            current_sentence = current_sentence[end_pos+1:]
+                            continue
+                        
+                        # 如果句号后紧跟空格，则更可能是句号
+                        if not (has_next and next_char.isspace()):
+                            # 这可能是缩写词中的点，不拆分
+                            if prev_char.isalpha() and (has_next and next_char.isalpha()):
+                                current_sentence = current_sentence[end_pos+1:]
+                                continue
+                    
+                    # 处理省略号的情况
+                    if end_mark == '…' or end_mark == '.':
+                        # 检查是否是"..."形式的省略号
+                        if end_mark == '.' and end_pos+2 < len(current_sentence):
+                            if current_sentence[end_pos:end_pos+3] == '...':
+                                # 提取完整的句子（包括省略号）
+                                complete_sentence = current_sentence[:end_pos+3]
+                                # 更新缓存，保留省略号后的内容
+                                current_sentence = current_sentence[end_pos+3:]
+                                print(f"【调试】[QwenClient] 发送完整句子(省略号): {complete_sentence}")
+                                yield complete_sentence
+                                continue
+                    
+                    # 提取完整的句子（包括结束符）
+                    complete_sentence = current_sentence[:end_pos+len(end_mark)]
+                    
+                    # 更新缓存，保留结束符后的内容
+                    current_sentence = current_sentence[end_pos+len(end_mark):]
+                    
+                    print(f"【调试】[QwenClient] 发送完整句子: {complete_sentence}")
+                    
+                    # 返回完整句子
+                    yield complete_sentence
+            
+            # 如果没有找到任何句子结束符但文本已经很长，也可以考虑发送（可选）
+            if not has_end_mark and len(current_sentence) > 100:
+                # 查找适合断句的位置，如逗号、分号等
+                break_positions = []
+                for mark in ['，', '；', '、', ',', ';']:
+                    pos = current_sentence.rfind(mark)
+                    if pos > 30:  # 至少要有30个字符才考虑断句
+                        break_positions.append(pos)
+                
+                if break_positions:
+                    # 找到最靠后的分隔符
+                    pos = max(break_positions)
+                    complete_sentence = current_sentence[:pos+1]
+                    current_sentence = current_sentence[pos+1:]
+                    print(f"【调试】[QwenClient] 发送长句中段落(按分隔符): {complete_sentence}")
+                    yield complete_sentence
+            
+        # 处理流式响应结束后，如果还有未发送的内容，作为最后一个句子发送
+        if current_sentence:
+            print(f"【调试】[QwenClient] 发送最后剩余内容: {current_sentence}")
+            yield current_sentence
+        
+        print(f"【调试】[QwenClient] 流式请求完成，完整响应: {full_response}")
+        
+        # 将模型响应添加到上下文历史
+        _llm_context.history.append(AgentResponseTurn(response=full_response))
+        
+    except Exception as e:
+        print(f"【调试】[QwenClient] 流式请求出错: {e}")
+        if current_sentence:
+            # 发送错误之前的最后内容
+            yield current_sentence
 
 
 async def simple_semantic_turn_detection(text: str) -> Optional[bool]:

--- a/backend/app/protocols/tts.py
+++ b/backend/app/protocols/tts.py
@@ -90,7 +90,7 @@ def extract_emotion_from_text(text: str) -> Tuple[str, TTSApiEmotion]:
         }
         emotion = emotion_map.get(emotion_str, TTSApiEmotion.NEUTRAL)
         
-        print(f"【TTS】从文本中提取到情绪标记: {emotion_str}, 对应枚举: {emotion.value}")
+        # print(f"【TTS】从文本中提取到情绪标记: {emotion_str}, 对应枚举: {emotion.value}")
         return cleaned_text, emotion
     
     # 没有找到情绪标记，返回原文本和默认情绪
@@ -559,19 +559,19 @@ class MiniMaxTTSClient(TTSClient):
         if api_emotion is None:
             cleaned_text, extracted_emotion = extract_emotion_from_text(text)
             if text != cleaned_text:  # 表示找到了情绪标记
-                text = cleaned_text
                 used_emotion = extracted_emotion
                 has_emotion_mark = True
-                print(f"【TTS】从文本中提取到情绪: {used_emotion.value}")
+                text = cleaned_text
+                # print(f"【TTS】从文本中提取到情绪: {used_emotion.value}")
             else:
                 # 文本中没有情绪标记，尝试使用上一句的情绪
                 if self.last_used_emotion:
                     used_emotion = self.last_used_emotion
-                    print(f"【TTS】使用上一句的情绪: {used_emotion.value}")
+                    # print(f"【TTS】使用上一句的情绪: {used_emotion.value}")
                 else:
                     # 没有上一句情绪，使用默认情绪
                     used_emotion = self.default_emotion
-                    print(f"【TTS】没有情绪标记和上一句情绪，使用默认情绪: {used_emotion.value}")
+                    # print(f"【TTS】没有情绪标记和上一句情绪，使用默认情绪: {used_emotion.value}")
         else:
             # 使用传入的情绪
             used_emotion = api_emotion
@@ -579,13 +579,13 @@ class MiniMaxTTSClient(TTSClient):
             if text.strip().startswith("["):
                 cleaned_text, _ = extract_emotion_from_text(text)
                 if text != cleaned_text:  # 表示找到了情绪标记
-                    text = cleaned_text
                     has_emotion_mark = True
+                    text = cleaned_text
         
         # 记住这次使用的情绪，供下次使用
         if has_emotion_mark:  # 只有当句子带有明确的情绪标记时才更新记忆
             self.last_used_emotion = used_emotion
-            print(f"【TTS】更新情绪记忆为: {used_emotion.value}")
+            # print(f"【TTS】更新情绪记忆为: {used_emotion.value}")
 
         ws = await self._establish_connection()
         if ws is None:

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -1,15 +1,17 @@
 # app/services/pipeline.py 将 STT -> STD -> Memory -> LLM -> TTS 串联起来
 
-from typing import Optional, Any, List, Callable, Dict
+from typing import Optional, Any, List, Callable, Dict, AsyncGenerator
 import asyncio
 import time
 import wave
 import torch
 from fastapi import WebSocket
+import queue
+from collections import deque
 
 from app.protocols.stt import AudioData, STTResponse, STTClient
 from app.protocols.stt import create_alicloud_stt_client
-from app.protocols.tts import MiniMaxTTSClient, TTSApiEmotion, get_tts_client
+from app.protocols.tts import MiniMaxTTSClient, TTSApiEmotion, get_tts_client, TTSResponse
 from app.tts.send_tts import send_tts_audio_stream
 # 初始化并注册命令检测器
 from app.memory.store import get_memory_manager
@@ -53,6 +55,10 @@ class PipelineService:
         
         # 初始化记忆客户端
         self.memory_client = None
+        
+        # 添加用于并行处理的队列
+        self.sentence_queue = asyncio.Queue()  # 句子队列，存储LLM生成的句子
+        self.tts_task = None  # TTS处理任务
         
         # print("【调试】PipelineService初始化完成")
         
@@ -103,6 +109,11 @@ class PipelineService:
         if not self.tts_monitor_task:
             self.tts_monitor_task = asyncio.create_task(self._monitor_stt_buffer())
             # print("【调试】STT缓冲区监控任务已启动")
+            
+        # 启动TTS处理任务
+        if not self.tts_task:
+            self.tts_task = asyncio.create_task(self._process_tts_queue())
+            print("【调试】TTS处理任务已启动")
         
     def stop(self) -> None:
         """停止Pipeline服务
@@ -116,6 +127,12 @@ class PipelineService:
             self.tts_monitor_task.cancel()
             self.tts_monitor_task = None
             # print("【调试】STT缓冲区监控任务已停止")
+            
+        # 停止TTS处理任务
+        if self.tts_task:
+            self.tts_task.cancel()
+            self.tts_task = None
+            print("【调试】TTS处理任务已停止")
             
         # print("【调试】Pipeline服务已停止")
         
@@ -212,55 +229,60 @@ class PipelineService:
             print(f"【错误】结束STT会话失败: {e}")
             return None
     
-    async def _monitor_stt_buffer(self) -> None:
-        """监控STT缓冲区
+    async def _process_tts_queue(self) -> None:
+        """处理TTS队列中的句子
         
-        定期检查STT缓冲区中是否有完整句子，如果有则进行TTS转换并播放
+        不断从队列中获取句子并进行TTS转换，然后发送到前端
         """
-        # print("【调试】开始监控STT缓冲区")
+        # print("【调试】开始处理TTS队列")
         
         # 确保TTS客户端已初始化
         if not self.tts_client:
             await self.init_tts_client()
+            
+        while self.running:
+            try:
+                # 从队列中获取一个句子
+                sentence = await self.sentence_queue.get()
+                
+                if sentence:
+                    # print(f"【调试】[TTS处理器] 处理句子: {sentence}")
+                    
+                    # 获取音频流并发送到前端
+                    audio_stream = self.tts_client.send_tts_request(None, sentence)
+                    await send_tts_audio_stream(audio_stream)
+                    
+                    # 标记任务完成
+                    self.sentence_queue.task_done()
+                
+            except asyncio.CancelledError:
+                print("【调试】TTS处理任务被取消")
+                break
+            except Exception as e:
+                print(f"【错误】处理TTS队列时出错: {e}")
+                await asyncio.sleep(0.1)  # 发生错误时等待一小段时间
+    
+    async def _monitor_stt_buffer(self) -> None:
+        """监控STT缓冲区
+        
+        定期检查STT缓冲区中是否有完整句子，如果有则启动LLM处理并将生成的句子放入TTS队列
+        """
+        print("【调试】开始监控STT缓冲区")
         
         while self.running:
             try:
-                # 如果当前没有在播放TTS，检查缓冲区是否有内容
-                if not self.tts_playing:
-                    sentences = await self.stt_client.get_complete_sentences()
-                    
-                    if sentences:                
-                        # 将所有句子合并为一段文本
-                        text = "，".join(sentences)
+                # 检查缓冲区是否有内容
+                sentences = await self.stt_client.get_complete_sentences()
+                
+                if sentences:                
+                    # 将所有句子合并为一段文本
+                    text = "，".join(sentences)
 
-                        # 清空缓冲区  
-                        cleared_count = await self.stt_client.clear_sentence_buffer()                     
+                    # 清空缓冲区  
+                    cleared_count = await self.stt_client.clear_sentence_buffer()   
 
-                        from app.llm.qwen_client import simple_send_request_to_llm
-
-                        # 发送消息到LLM
-                        # 使用修改后的流式输出，每个句子单独处理
-                        # 异步生成器不能使用await，直接获取生成器
-                        llm_response_generator = simple_send_request_to_llm(text)
-                        
-                        # 处理每个生成的完整句子
-                        async for sentence in llm_response_generator:
-                            if not sentence:
-                                continue
-                                
-                            print(f"【调试】[Pipeline] 收到完整句子: {sentence}")
-                            
-                            # 播放TTS
-                            self.tts_playing = True
-                            # 获取音频流并发送到前端
-                            audio_stream = self.tts_client.send_tts_request(None, sentence)
-                            await send_tts_audio_stream(audio_stream)
-                            
-                            # 每个句子播放完成后，重置状态
-                            self.tts_playing = False
-                            
-                            # 给TTS一点时间处理
-                            # await asyncio.sleep(0.1)
+                    # 启动异步任务处理LLM响应
+                    asyncio.create_task(self._process_llm_response(text))
                 
                 # 等待下一次检查
                 await asyncio.sleep(self.check_interval)
@@ -271,6 +293,33 @@ class PipelineService:
             except Exception as e:
                 print(f"【错误】监控STT缓冲区时出错: {e}")
                 await asyncio.sleep(self.check_interval)  # 发生错误时也等待下一个间隔
+    
+    async def _process_llm_response(self, text: str) -> None:
+        """处理LLM响应
+        
+        接收用户输入文本，发送到LLM，并将生成的句子放入TTS队列
+        
+        Args:
+            text: 用户输入文本
+        """
+        try:
+            from app.llm.qwen_client import simple_send_request_to_llm
+            
+            # 发送消息到LLM并获取响应生成器
+            llm_response_generator = simple_send_request_to_llm(text)
+            
+            # 处理每个生成的完整句子
+            async for sentence in llm_response_generator:
+                if not sentence:
+                    continue
+                    
+                print(f"【调试】[Pipeline] 收到完整句子: {sentence}")
+                
+                # 将句子放入队列，供TTS处理器处理
+                await self.sentence_queue.put(sentence)
+                
+        except Exception as e:
+            print(f"【错误】处理LLM响应时出错: {e}")
     
     async def _run_callback(self, callback: Callable, text: str, is_final: bool) -> None:
         """运行回调函数

--- a/backend/app/tts/send_tts.py
+++ b/backend/app/tts/send_tts.py
@@ -57,7 +57,7 @@ async def send_tts_audio_stream(audio_stream: AsyncGenerator[Union[bytes, TTSRes
             pass
         return
 
-    print("[TTS发送器] 客户端已连接，开始发送TTS音频流。")
+    # print("[TTS发送器] 客户端已连接，开始发送TTS音频流。")
     try:
         # 收集所有PCM块合并后一次性发送
         all_pcm_chunks = []

--- a/backend/app/utils/request.py
+++ b/backend/app/utils/request.py
@@ -4,7 +4,7 @@ import asyncio
 import aiohttp
 import app.core.config as config
 import app.utils.exception as exception
-from typing import List, Tuple, Dict, Optional, Any, Union
+from typing import List, Tuple, Dict, Optional, Any, Union, AsyncGenerator, Callable
 from app.utils.entity import Request
 from app.utils.api_checker import api_checker
 import atexit
@@ -518,3 +518,565 @@ def send_request(messages, model_name, max_retries=config.max_retries, timeout=c
             return loop.run_until_complete(
                 send_request_async(messages, model_name, max_retries, timeout, temperature, top_p)
             )
+
+async def _send_stream_request_async(messages: List, request: Request, timeout=config.wait_timeout) -> AsyncGenerator[Tuple[str, int, int], None]:
+    """
+    异步发送流式请求给模型
+    :param messages: 消息队列
+    :param request: 包含模型信息的请求对象
+    :param timeout: 超时时间
+    :return: 返回一个异步生成器，每个生成项为(当前内容块, 累计token, 增量token)
+    """
+    # 默认值
+    model, api_key, url = request.model, request.api_key, request.url
+
+    if config.debug_request:
+        print(f"发送流式请求: {messages}")
+        # 断点
+        breakpoint()
+
+    payload = {
+        "messages": messages,
+        "model": model,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+        "response_format": {
+            "type": "text"
+        },
+        "stop": None,
+        "stream": True,  # 启用流式输出
+        "temperature": request.temperature,
+        "top_p": request.top_p,
+        "tools": None,
+        "logprobs": False,
+        "top_logprobs": None,
+        "thinking_budget": 0
+    }
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': f'Bearer {api_key}'
+    }
+
+    try:
+        # 记录请求开始时间 (用于计算响应时间)
+        start_time = time.time()
+        
+        # 使用全局共享的session
+        session = await get_session()
+        
+        # 流式响应的累计token数
+        total_token = 0
+        generation_token = 0
+        accumulated_content = ""
+        
+        # 使用共享session进行异步请求
+        async with session.post(url, headers=headers, json=payload, timeout=timeout) as response:
+            # 计算响应时间 (毫秒)
+            response_time_ms = (time.time() - start_time) * 1000
+            
+            # 检查响应状态
+            if response.status != 200:
+                error_detail = ""
+                try:
+                    error_json = await response.json()
+                    # 提取错误详情
+                    if 'error' in error_json:
+                        error_obj = error_json['error']
+                        if isinstance(error_obj, dict):
+                            error_detail = f"错误信息: {error_obj.get('message', '')}, 类型: {error_obj.get('type', '')}, 代码: {error_obj.get('code', '')}"
+                        else:
+                            error_detail = f"错误信息: {error_obj}"
+                    elif 'message' in error_json:
+                        error_detail = f"错误信息: {error_json['message']}"
+                    else:
+                        error_detail = f"API响应: {json.dumps(error_json, ensure_ascii=False)}"
+                except:
+                    # 如果无法解析为JSON，获取文本响应
+                    try:
+                        text = await response.text()
+                        error_detail = f"错误响应: {text[:500]}"  # 限制长度
+                    except:
+                        error_detail = "无法获取错误详情"
+                
+                # 记录请求失败
+                if _has_monitor:
+                    try:
+                        monitor.record_request(
+                            api_key=api_key,
+                            success=False,
+                            tokens=0,
+                            completion_tokens=0,
+                            response_time_ms=response_time_ms,
+                            current_model=model
+                        )
+                    except Exception as e:
+                        # 不要让监控错误影响主要功能
+                        pass
+
+                # 构建并抛出异常
+                raise aiohttp.ClientResponseError(
+                    request_info=response.request_info,
+                    history=response.history,
+                    status=response.status,
+                    message=f"{response.status} {response.reason} - {error_detail}",
+                    headers=response.headers
+                )
+
+            # 处理流式响应
+            try:
+                async for line in response.content:
+                    try:
+                        line_text = line.decode('utf-8').strip()
+                        if not line_text:
+                            continue
+                            
+                        # 跳过前缀 "data: "
+                        if line_text.startswith('data: '):
+                            line_text = line_text[6:]
+                        
+                        # 如果是流式结束标记 [DONE]
+                        if line_text == '[DONE]':
+                            # 最终完整响应
+                            if _has_monitor:
+                                try:
+                                    monitor.record_request(
+                                        api_key=api_key,
+                                        success=True,
+                                        tokens=total_token,
+                                        completion_tokens=generation_token,
+                                        response_time_ms=(time.time() - start_time) * 1000,
+                                        current_model=model
+                                    )
+                                except Exception as e:
+                                    # 不要让监控错误影响主要功能
+                                    pass
+                            break
+                        
+                        try:
+                            # 解析JSON响应块
+                            data = json.loads(line_text)
+                            
+                            # 对于Claude命令模型的特殊处理
+                            if "command" in model:
+                                # 增加健壮性检查，确保所有需要的字段都存在
+                                message_content = data.get('message', {}).get('content')
+                                if data.get('usage') and message_content:
+                                    # 确保content是一个列表且有元素
+                                    if isinstance(message_content, list) and len(message_content) > 0:
+                                        # 确保第一个元素有text字段
+                                        content_item = message_content[0]
+                                        if isinstance(content_item, dict) and 'text' in content_item:
+                                            content = content_item['text']
+                                            # 确保usage字段的完整性
+                                            if 'tokens' in data['usage']:
+                                                tokens = data['usage']['tokens']
+                                                if 'input_tokens' in tokens and 'output_tokens' in tokens:
+                                                    input_tokens = tokens['input_tokens']
+                                                    output_tokens = tokens['output_tokens']
+                                                    
+                                                    # 累计token使用量
+                                                    total_token = input_tokens + output_tokens
+                                                    generation_token = output_tokens
+                                                    
+                                                    # 更新累计内容，确保现有内容不为None
+                                                    if accumulated_content is None:
+                                                        accumulated_content = ""
+                                                    delta_content = content[len(accumulated_content):]
+                                                    accumulated_content = content
+                                                    
+                                                    # 生成一个响应项
+                                                    yield delta_content, total_token, generation_token
+                                    continue
+                                    
+                            # 处理普通GPT模型的流式响应
+                            if 'choices' in data and isinstance(data['choices'], list) and len(data['choices']) > 0:
+                                choice = data['choices'][0]
+                                
+                                # 提取增量内容
+                                delta = choice.get('delta', {})
+                                if not isinstance(delta, dict):
+                                    delta = {}  # 确保delta是字典类型
+                                
+                                content = delta.get('content', '')
+                                
+                                if content:
+                                    # 更新累计内容，确保现有内容不为None
+                                    if accumulated_content is None:
+                                        accumulated_content = ""
+                                    accumulated_content += content
+                                    
+                                    # 累计token使用量 (准确值需要在最后获取，这里是估算)
+                                    # 大约4个字符为1个token
+                                    approx_tokens = len(content) // 4 + 1
+                                    generation_token += approx_tokens
+                                    total_token += approx_tokens
+                                    
+                                    # 生成一个响应项
+                                    yield content, total_token, generation_token
+                                
+                                # 如果是最后一个块，可能包含token统计信息
+                                if choice.get('finish_reason') is not None:
+                                    # 确保usage字段存在并且包含必要的信息
+                                    if 'usage' in data and isinstance(data['usage'], dict):
+                                        usage = data['usage']
+                                        if 'total_tokens' in usage:
+                                            total_token = usage['total_tokens']
+                                        if 'completion_tokens' in usage:
+                                            generation_token = usage['completion_tokens']
+
+                        except json.JSONDecodeError:
+                            # 跳过无法解析的行
+                            continue
+                        except Exception as e:
+                            exception.print_warning(
+                                _send_stream_request_async,
+                                f"处理流式响应块时出错: {e}",
+                                "低风险"
+                            )
+                            continue
+                    except Exception as line_e:
+                        # 处理每行数据过程中的错误
+                        exception.print_warning(
+                            _send_stream_request_async,
+                            f"处理流式响应行时出错: {line_e}",
+                            "低风险"
+                        )
+            except Exception as stream_e:
+                # 处理整个流式迭代过程中的错误
+                exception.print_warning(
+                    _send_stream_request_async,
+                    f"流式响应迭代出错: {stream_e}",
+                    "中风险"
+                )
+
+    except asyncio.TimeoutError:
+        # 记录请求超时
+        if _has_monitor:
+            try:
+                monitor.record_request(
+                    api_key=api_key,
+                    success=False,
+                    tokens=0,
+                    completion_tokens=0,
+                    response_time_ms=(time.time() - start_time) * 1000,
+                    current_model=model
+                )
+            except Exception as e:
+                pass
+        raise asyncio.TimeoutError("流式请求超时，请检查网络连接或增加超时时间。")
+    except Exception as e:
+        # 记录其他错误
+        if _has_monitor:
+            try:
+                monitor.record_request(
+                    api_key=api_key,
+                    success=False,
+                    tokens=0,
+                    completion_tokens=0,
+                    response_time_ms=(time.time() - start_time) * 1000,
+                    current_model=model
+                )
+            except Exception as ex:
+                pass
+        raise Exception(f"流式请求失败: {e}")
+
+
+async def _send_stream_request_with_retry_async(messages, request, max_retries, timeout):
+    """
+    使用指数级延迟重试异步发送流式请求。
+    :param messages: 要发送的消息
+    :param request: 请求对象
+    :param max_retries: 最大重试次数
+    :param timeout: 每次请求的超时时间（秒）
+    :return: 异步生成器，生成(当前内容块, 累计token, 增量token)
+    """
+    retries = 0  # 当前实际执行的次数
+    delay = 1.0  # 初始延迟1秒
+
+    while retries <= max_retries:
+        try:
+            # 调用异步流式请求函数
+            async for chunk, total_token, generation_token in _send_stream_request_async(messages, request, timeout=timeout):
+                yield chunk, total_token, generation_token
+            return  # 成功完成整个流式输出后结束
+
+        except Exception as e:
+            retries += 1
+            
+            if "402" in str(e):
+                # 直接放弃，没钱了，切换
+                exception.print_error(_send_stream_request_with_retry_async, f"没钱了，切换API: {e}")
+                raise Exception("没钱了，切换API")
+            
+            if "429" in str(e):
+                # 对于429错误特殊处理
+                delay = min(delay * 2, config.cool_down_time * 5) * (retries / 10.0) # 限制最大延迟时间
+                await asyncio.sleep(delay)
+                # 大于3次再打印
+                if retries > 100:
+                    exception.print_warning(
+                        _send_stream_request_with_retry_async,
+                        f"速率限制错误: {e}. 正在重试流式请求 {retries}/{max_retries}，延迟 {delay} 秒后重试。",
+                        "中风险"
+                    )
+            elif isinstance(e, aiohttp.ClientConnectorError):
+                # 网络错误延迟高一点
+                delay = min(delay * 2, config.cool_down_time * 50) * (retries / 10.0)  # 限制最大延迟时间
+                await asyncio.sleep(delay)
+                # 大于3次再打印
+                if retries > 3:
+                    exception.print_warning(
+                        _send_stream_request_with_retry_async,
+                        f"网络连接错误: {e}. 正在重试流式请求 {retries}/{max_retries}，延迟 {delay} 秒后重试。",
+                        "中风险"
+                    )
+            else:
+                # 其他所有错误都重试
+                delay = min(delay * 1.5, config.cool_down_time * 5) * (retries / 10.0)  # 限制最大延迟时间
+                await asyncio.sleep(delay)
+                # 大于3次再打印
+                if retries > 3:
+                    exception.print_warning(
+                        _send_stream_request_with_retry_async,
+                        f"流式请求错误: {e}. 正在重试 {retries}/{max_retries}，延迟 {delay} 秒后重试。",
+                        "高风险"
+                    )
+            
+            # 检查是否达到最大重试次数
+            if retries > max_retries:
+                exception.print_error(_send_stream_request_with_retry_async, "重试次数过多，流式网络请求失败！")
+                raise Exception(f"流式请求超过最大重试次数: {e}")
+
+    # 这行代码理论上不会执行到，因为在循环内部会处理所有情况
+    exception.print_error(_send_stream_request_with_retry_async, "重试次数过多，流式网络请求失败！")
+    raise Exception("流式请求超过最大重试次数")
+
+
+async def send_stream_request_async(messages: List[Dict[str, str]], model_name, callback: Optional[Callable[[str, int, int], None]] = None,
+                              max_retries=config.max_retries, timeout=config.wait_timeout, 
+                              temperature=config.temperature, top_p=config.top_p):
+    """
+    异步发送流式请求，根据需要的模型名称，逐块返回响应。
+    包含获取可用API的指数退避重试逻辑，以处理速率限制。
+
+    :param messages: 要发送的消息 (字典列表)
+    :param model_name: 模型名称
+    :param callback: 可选的回调函数，接收(chunk, total_token, generation_token)参数
+    :param max_retries: 最大重试次数
+    :param timeout: 超时时间（秒）
+    :param temperature: 温度参数
+    :param top_p: top_p参数
+    :return: 异步生成器，生成(当前内容块, 累计token, 增量token)
+    """
+    retries = 0
+    delay = 1.0
+    last_exception = None # 保存最后一次遇到的异常
+
+    # 从模型名称中解析出供应商信息
+    provider = None
+    actual_model_name = model_name
+
+    # 检查模型名称是否包含供应商信息（使用下划线分隔）
+    if "_" in model_name:
+        parts = model_name.split("_")
+        if len(parts) >= 2:
+            actual_model_name = parts[0]  # 实际模型名称
+            provider = parts[-1]  # 供应商名称
+    
+    while retries <= max_retries:
+        request = None # 在每次重试开始时重置 request
+
+        try:
+            # 1. 获取可用 API，传递提取出的供应商信息
+            request = api_checker.get_available_api(actual_model_name, provider=provider)
+            if request is None:
+                exception.print_warning(
+                    send_stream_request_async,
+                    f"没有找到模型 '{actual_model_name}' 的可用API。正在重试 {retries}/{max_retries}...",
+                    "中风险"
+                )
+                last_exception = Exception(f"No available API found for model '{actual_model_name}'")
+                # 等待后继续下一次尝试
+                await asyncio.sleep(delay)
+                retries += 1
+                continue # 进入下一次循环，尝试重新获取API
+
+            # 修改请求参数
+            request.temperature = temperature  # type: ignore
+            request.top_p = top_p  # type: ignore
+
+            # 3. 发送流式请求 (内部已有重试逻辑)
+            # 内部重试次数减少，因为外部已有重试循环
+            internal_max_retries = max(1, max_retries // 2) # 至少重试1次
+            
+            # 更新GUI状态信息
+            if _has_monitor:
+                try:
+                    monitor.update_status(f"正在流式请求 {actual_model_name} 模型 (Key: ...{request.api_key[-6:]})")
+                except Exception as e:
+                    # 不要让GUI更新失败影响正常业务
+                    pass
+
+            # 流式处理
+            full_content = ""
+            final_total_token = 0
+            final_generation_token = 0
+            
+            async for chunk, total_token, generation_token in _send_stream_request_with_retry_async(
+                messages, request, max_retries=internal_max_retries, timeout=timeout
+            ):
+                # 更新最终token计数
+                final_total_token = total_token
+                final_generation_token = generation_token
+                full_content += chunk
+                
+                # 执行回调（如果提供）
+                if callback:
+                    callback(chunk, total_token, generation_token)
+                    
+                # 生成当前块
+                yield chunk, total_token, generation_token
+            
+            # 更新GUI状态信息
+            if _has_monitor:
+                try:
+                    monitor.update_status(f"流式请求成功 (模型: {actual_model_name}, 生成: {final_generation_token} tokens)")
+                except Exception as e:
+                    # 不要让GUI更新失败影响正常业务
+                    pass
+                    
+            # 请求成功，流式处理完成，退出重试循环
+            return
+
+        except Exception as e:
+            # 捕获流式请求过程中抛出的异常
+            last_exception = e # 保存异常信息
+            exception.print_warning(
+                send_stream_request_async,
+                f"流式请求或处理过程中发生错误: {e}. 正在重试 {retries}/{max_retries} (等待 {delay:.2f}s)...",
+                "高风险"
+            )
+            
+            # 更新GUI状态信息
+            if _has_monitor:
+                try:
+                    monitor.update_status(f"流式请求失败，正在重试... ({retries}/{max_retries})")
+                except Exception as ex:
+                    # 不要让GUI更新失败影响正常业务
+                    pass
+                    
+            # 等待后继续下一次尝试
+            await asyncio.sleep(delay)
+            retries += 1
+            delay = min(delay * 1.5, timeout * 8) # 发生错误，增加延迟
+            # 不需要手动 continue，循环会自动继续
+
+    # 如果所有重试都失败了
+    exception.print_error(
+        send_stream_request_async,
+        f"经过 {max_retries + 1} 次尝试后，流式请求最终失败 (模型: {actual_model_name})。最后错误: {last_exception}",
+    )
+    
+    # 更新GUI状态信息
+    if _has_monitor:
+        try:
+            monitor.update_status(f"流式请求彻底失败 (模型: {actual_model_name}，已尝试 {max_retries+1} 次)")
+        except Exception as e:
+            # 不要让GUI更新失败影响正常业务
+            pass
+    
+    # 抛出最后的异常
+    if last_exception:
+        raise last_exception
+    else:
+        raise Exception(f"流式请求失败，模型: {model_name}，已尝试 {max_retries+1} 次")
+
+
+# 兼容同步调用的包装函数
+def send_stream_request(messages, model_name, callback=None, max_retries=config.max_retries, 
+                        timeout=config.wait_timeout, temperature=config.temperature, top_p=config.top_p):
+    """
+    同步版本的send_stream_request，内部调用异步版本。
+    强烈建议直接使用 await send_stream_request_async(...)。
+    
+    :param messages: 要发送的消息 (字典列表)
+    :param model_name: 模型名称
+    :param callback: 可选的回调函数，接收(chunk, total_token, generation_token)参数
+    :param max_retries: 最大重试次数
+    :param timeout: 超时时间（秒）
+    :param temperature: 温度参数
+    :param top_p: top_p参数
+    :return: 完整的响应内容，总体token，生成token
+    """
+    full_content = ""
+    final_total_token = 0
+    final_generation_token = 0
+    
+    def chunk_collector(chunk, total_token, generation_token):
+        nonlocal full_content, final_total_token, final_generation_token
+        full_content += chunk
+        final_total_token = total_token
+        final_generation_token = generation_token
+        # 同时调用用户提供的回调（如果有）
+        if callback:
+            callback(chunk, total_token, generation_token)
+
+    try:
+        # 尝试获取当前线程的事件循环
+        loop = asyncio.get_event_loop_policy().get_event_loop()
+    except RuntimeError:
+        # 如果当前线程没有事件循环，则创建一个新的
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            # 在新创建的循环中运行异步任务
+            async def process_stream():
+                async for chunk, total_token, generation_token in send_stream_request_async(
+                    messages, model_name, callback=chunk_collector, 
+                    max_retries=max_retries, timeout=timeout, 
+                    temperature=temperature, top_p=top_p
+                ):
+                    # 这里不需要做任何事，chunk_collector已经处理了数据
+                    pass
+            
+            loop.run_until_complete(process_stream())
+            return full_content, final_total_token, final_generation_token
+        finally:
+            # 清理：关闭循环并取消设置
+            loop.close()
+            asyncio.set_event_loop(None)  # 确保清理干净
+    else:
+        # 如果当前线程已有事件循环
+        if loop.is_running():
+            # 如果循环正在运行（例如在另一个异步函数中调用此同步函数）
+            # 创建一个新循环在其中运行，以避免嵌套 run_until_complete 的问题
+            new_loop = asyncio.new_event_loop()
+            try:
+                async def process_stream():
+                    async for chunk, total_token, generation_token in send_stream_request_async(
+                        messages, model_name, callback=chunk_collector, 
+                        max_retries=max_retries, timeout=timeout, 
+                        temperature=temperature, top_p=top_p
+                    ):
+                        # 这里不需要做任何事，chunk_collector已经处理了数据
+                        pass
+                
+                new_loop.run_until_complete(process_stream())
+                return full_content, final_total_token, final_generation_token
+            finally:
+                new_loop.close()
+        else:
+            # 如果循环存在但未运行，直接使用它
+            async def process_stream():
+                async for chunk, total_token, generation_token in send_stream_request_async(
+                    messages, model_name, callback=chunk_collector, 
+                    max_retries=max_retries, timeout=timeout, 
+                    temperature=temperature, top_p=top_p
+                ):
+                    # 这里不需要做任何事，chunk_collector已经处理了数据
+                    pass
+            
+            loop.run_until_complete(process_stream())
+            return full_content, final_total_token, final_generation_token


### PR DESCRIPTION
## ✅ 功能修改说明

### 1. `qwen_client.py`

#### 函数：`simple_send_request_to_llm`

* **新增逻辑**：
  支持大模型响应的 **流式输出**。每次从大模型接收一段文本后，根据结束符（如 `。！？`）判断是否为完整句子。
* **情绪标注要求**：
  每一个完整句子前必须有情绪标注（如 `[HAPPY]`、`[ANGRY]`），除非与上一句相同。
* **输出行为**：
  每完成一句句子解析，就立即通过发送给 `pipeline` 进行 TTS 处理。

---

### 2. `tts.py`

#### 新增逻辑：

* **情绪记忆机制**：
  若当前句子没有情绪标注，则自动复用上一句的情绪。
* **Bug 修复**：

---

### 3. `pipeline.py`

#### 功能扩展：

* **接收流式句子**：
  支持来自 `qwen_client` 的一条条完整句子输入。
* **逐句 TTS 播放**：
  每接收到一句，就立即执行 TTS，播放完成后释放资源，准备接收下一句。

---

### 4. `request.py`

#### 新增函数：

* 参考现有的 `send_request_async` 实现，
  实现 **支持流式输出的请求函数**，能逐步接收 LLM 返回的数据块。

---

## ⚠️ 当前流程存在的问题

| 问题   | 描述                         |
| ---- | -------------------------- |
| 串行处理 | 整个流程为严格同步：必须等一项完成才能进行下一项。  |
| 无法抢占 | 用户必须等 LLM 输出完全后，才能输入下一条内容。 |

---

考虑到解决上面问题可以会对pipeline.py有比较大的改动，暂不实现